### PR TITLE
Render index as static HTML (remove React/Babel) to fix black screen

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,171 +8,128 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://kit.fontawesome.com/a315f1122c.js" crossorigin="anonymous"></script>
 </head>
 <body class="font-[Montserrat] antialiased bg-black text-white">
-  <div id="root"></div>
-
-  <script type="text/babel">
-    const MenuItem = ({ children }) => (
-      <a
-        href={`#${children.toLowerCase()}`}
-        className="px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300"
-      >
-        {children}
-      </a>
-    );
-
-    const Header = () => {
-      const [open, setOpen] = React.useState(false);
-      return (
-        <header className="bg-black shadow-md fixed w-full z-20">
-          <div className="max-w-7xl mx-auto flex justify-between items-center p-4">
-            <img src="images/disiclogo.png" alt="DISIC" className="h-16" />
-            <nav className="hidden md:flex items-center space-x-4">
-              <MenuItem>Inicio</MenuItem>
-              <MenuItem>Nosotros</MenuItem>
-              <div className="relative group inline-block px-3 py-2">
-                <a href="#servicios" className="text-gray-300 group-hover:text-red-500 transition-colors duration-300">Servicios</a>
-                <div className="absolute left-0 mt-2 hidden group-hover:block bg-black shadow-lg">
-                  <a href="#extintores" className="block px-4 py-2 hover:bg-red-700">Extintores</a>
-                  <a href="#senalamientos" className="block px-4 py-2 hover:bg-red-700">Señalización</a>
-                  <a href="#tech" className="block px-4 py-2 hover:bg-red-700">DISIC Tech & Fire</a>
-                </div>
-              </div>
-              <MenuItem>Clientes</MenuItem>
-              <MenuItem>Blog</MenuItem>
-              <MenuItem>Contacto</MenuItem>
-            </nav>
-            <button className="md:hidden text-gray-300 hover:text-red-500 transition-colors duration-300" onClick={() => setOpen(!open)}><i className="fas fa-bars"></i></button>
-            <a href="#contacto" className="hidden md:inline-block bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition-colors duration-300">Solicita Cotización</a>
+  <header class="bg-black shadow-md fixed w-full z-20">
+    <div class="max-w-7xl mx-auto flex justify-between items-center p-4">
+      <img src="images/disiclogo.png" alt="DISIC" class="h-16" />
+      <nav class="hidden md:flex items-center space-x-4">
+        <a href="#inicio" class="px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Inicio</a>
+        <a href="#nosotros" class="px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Nosotros</a>
+        <div class="relative group inline-block px-3 py-2">
+          <a href="#servicios" class="text-gray-300 group-hover:text-red-500 transition-colors duration-300">Servicios</a>
+          <div class="absolute left-0 mt-2 hidden group-hover:block bg-black shadow-lg">
+            <a href="#extintores" class="block px-4 py-2 hover:bg-red-700">Extintores</a>
+            <a href="#senalamientos" class="block px-4 py-2 hover:bg-red-700">Señalización</a>
+            <a href="#tech" class="block px-4 py-2 hover:bg-red-700">DISIC Tech & Fire</a>
           </div>
-          {open && (
-            <div className="md:hidden bg-black p-4 space-y-2">
-              <MenuItem>Inicio</MenuItem>
-              <MenuItem>Nosotros</MenuItem>
-              <MenuItem>Servicios</MenuItem>
-              <MenuItem>Clientes</MenuItem>
-              <MenuItem>Blog</MenuItem>
-              <MenuItem>Contacto</MenuItem>
-              <a href="#contacto" className="block bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition-colors duration-300">Solicita Cotización</a>
-            </div>
-          )}
-        </header>
-      );
-    };
-
-    const Hero = () => (
-      <section id="inicio" className="relative h-screen flex items-center justify-center overflow-hidden">
-        <video
-          src="fire.mp4"
-          autoPlay
-          loop
-          muted
-          playsInline
-          className="absolute inset-0 w-full h-full object-cover"
-        ></video>
-        <div className="relative z-10 bg-black bg-opacity-70 p-8 rounded text-center">
-          <h1 className="text-3xl md:text-5xl font-bold mb-4">Instalación y mantenimiento profesional de sistemas contra incendio</h1>
-          <a href="#servicios" className="bg-red-600 text-white px-6 py-3 rounded hover:bg-red-700 inline-block">Conoce nuestros servicios</a>
         </div>
-      </section>
-    );
+        <a href="#clientes" class="px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Clientes</a>
+        <a href="#blog" class="px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Blog</a>
+        <a href="#contacto" class="px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Contacto</a>
+      </nav>
+      <button id="menu-toggle" class="md:hidden text-gray-300 hover:text-red-500 transition-colors duration-300" aria-label="Abrir menú">
+        <i class="fas fa-bars"></i>
+      </button>
+      <a href="#contacto" class="hidden md:inline-block bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition-colors duration-300">Solicita Cotización</a>
+    </div>
+    <div id="mobile-menu" class="hidden md:hidden bg-black p-4 space-y-2">
+      <a href="#inicio" class="block px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Inicio</a>
+      <a href="#nosotros" class="block px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Nosotros</a>
+      <a href="#servicios" class="block px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Servicios</a>
+      <a href="#clientes" class="block px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Clientes</a>
+      <a href="#blog" class="block px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Blog</a>
+      <a href="#contacto" class="block px-3 py-2 text-gray-300 hover:text-red-500 transition-colors duration-300">Contacto</a>
+      <a href="#contacto" class="block bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 transition-colors duration-300">Solicita Cotización</a>
+    </div>
+  </header>
 
-    const ServiceCard = ({ icon, title }) => (
-      <div className="bg-black shadow-md rounded p-6 text-center flex flex-col items-center text-white">
-        <i className={`fas fa-${icon} text-red-500 text-3xl mb-4`}></i>
-        <h3 className="font-semibold text-lg">{title}</h3>
+  <main>
+    <section id="inicio" class="relative h-screen flex items-center justify-center overflow-hidden">
+      <video
+        src="fire.mp4"
+        autoPlay
+        loop
+        muted
+        playsInline
+        class="absolute inset-0 w-full h-full object-cover"
+      ></video>
+      <div class="relative z-10 bg-black bg-opacity-70 p-8 rounded text-center">
+        <h1 class="text-3xl md:text-5xl font-bold mb-4">Instalación y mantenimiento profesional de sistemas contra incendio</h1>
+        <a href="#servicios" class="bg-red-600 text-white px-6 py-3 rounded hover:bg-red-700 inline-block">Conoce nuestros servicios</a>
       </div>
-    );
+    </section>
 
-    const TechFire = () => (
-      <section id="tech" className="py-16 bg-black text-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <h2 className="text-2xl font-bold text-center mb-2">DISIC Tech & Fire</h2>
-          <h3 className="text-xl text-center mb-4">Sistemas de Detección y Combate</h3>
-          <p className="mb-4">DISIC Tech & Fire es nuestra área especializada en la instalación, programación y mantenimiento de sistemas de detección y combate contra incendios. Implementamos soluciones convencionales e inteligentes, adaptadas a cada tipo de edificio o industria. Usamos paneles, detectores, estaciones manuales, rociadores, bombas y más, con equipos de marcas reconocidas y conforme a la NFPA y la NOM-002-STPS.</p>
-          <h4 className="font-semibold mb-2">Servicios incluidos:</h4>
-          <ul className="list-disc list-inside space-y-1">
-            <li>Instalación de sistemas de detección automática (convencional e inteligente)</li>
-            <li>Mantenimiento y pruebas funcionales periódicas</li>
-            <li>Integración con sistemas de alarma, hidrantes y rociadores</li>
-          </ul>
-        </div>
-      </section>
-    );
-
-    const WhyUs = () => (
-      <section className="py-16">
-        <div className="max-w-7xl mx-auto px-4">
-          <h2 className="text-2xl font-bold text-center mb-8">¿Por qué elegirnos?</h2>
-          <div className="grid gap-6 md:grid-cols-4 text-center">
-            <div><i className="fas fa-user-tie text-red-600 text-3xl mb-2"></i><p>Experiencia</p></div>
-            <div><i className="fas fa-certificate text-red-600 text-3xl mb-2"></i><p>Certificación</p></div>
-            <div><i className="fas fa-users text-red-600 text-3xl mb-2"></i><p>Clientes</p></div>
-            <div><i className="fas fa-globe text-red-600 text-3xl mb-2"></i><p>Cobertura</p></div>
-          </div>
-        </div>
-      </section>
-    );
-
-    const About = () => (
-      <section id="nosotros" className="py-16 bg-red-950">
-        <div className="max-w-7xl mx-auto px-4">
-          <h2 className="text-2xl font-bold text-center mb-8">Nosotros</h2>
-          <p className="mb-4">DISIC es una empresa dedicada a la venta, renta y mantenimiento de extintores. Nuestro compromiso es ofrecer soluciones integrales de seguridad industrial y comercial.</p>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div><h3 className="font-semibold mb-2">Misión</h3><p>Proteger la vida y el patrimonio de nuestros clientes.</p></div>
-            <div><h3 className="font-semibold mb-2">Visión</h3><p>Ser líderes en soluciones de seguridad contra incendios.</p></div>
-            <div><h3 className="font-semibold mb-2">Valores</h3><p>Compromiso, innovación y servicio.</p></div>
-          </div>
-        </div>
-      </section>
-    );
-
-    const Contact = () => (
-      <section id="contacto" className="py-16">
-        <div className="max-w-7xl mx-auto px-4">
-          <h2 className="text-2xl font-bold text-center mb-8">Contacto</h2>
-          <form className="grid gap-4 md:grid-cols-2">
-            <input type="text" placeholder="Nombre" className="border p-2 rounded"/>
-            <input type="email" placeholder="Correo" className="border p-2 rounded"/>
-            <textarea placeholder="Mensaje" className="border p-2 rounded md:col-span-2" rows="4"></textarea>
-            <button className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 md:col-span-2" type="submit">Enviar</button>
-          </form>
-        </div>
-      </section>
-    );
-
-    const Footer = () => (
-      <footer className="bg-red-800 text-white py-6">
-        <div className="max-w-7xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center">
-          <p>&copy; 2025 DISIC</p>
-          <div className="space-x-4 text-xl">
-            <a href="#" className="hover:text-red-500"><i className="fab fa-facebook"></i></a>
-            <a href="#" className="hover:text-red-500"><i className="fab fa-instagram"></i></a>
-            <a href="#" className="hover:text-red-500"><i className="fab fa-linkedin"></i></a>
-          </div>
-        </div>
-      </footer>
-    );
-
-    const App = () => (
-      <div>
-        <Header />
-        <Hero />
-        <TechFire />
-        <WhyUs />
-        <About />
-        <Contact />
-        <Footer />
+    <section id="tech" class="py-16 bg-black text-white">
+      <div class="max-w-7xl mx-auto px-4">
+        <h2 class="text-2xl font-bold text-center mb-2">DISIC Tech & Fire</h2>
+        <h3 class="text-xl text-center mb-4">Sistemas de Detección y Combate</h3>
+        <p class="mb-4">DISIC Tech & Fire es nuestra área especializada en la instalación, programación y mantenimiento de sistemas de detección y combate contra incendios. Implementamos soluciones convencionales e inteligentes, adaptadas a cada tipo de edificio o industria. Usamos paneles, detectores, estaciones manuales, rociadores, bombas y más, con equipos de marcas reconocidas y conforme a la NFPA y la NOM-002-STPS.</p>
+        <h4 class="font-semibold mb-2">Servicios incluidos:</h4>
+        <ul class="list-disc list-inside space-y-1">
+          <li>Instalación de sistemas de detección automática (convencional e inteligente)</li>
+          <li>Mantenimiento y pruebas funcionales periódicas</li>
+          <li>Integración con sistemas de alarma, hidrantes y rociadores</li>
+        </ul>
       </div>
-    );
+    </section>
 
-    ReactDOM.render(<App />, document.getElementById('root'));
+    <section class="py-16">
+      <div class="max-w-7xl mx-auto px-4">
+        <h2 class="text-2xl font-bold text-center mb-8">¿Por qué elegirnos?</h2>
+        <div class="grid gap-6 md:grid-cols-4 text-center">
+          <div><i class="fas fa-user-tie text-red-600 text-3xl mb-2"></i><p>Experiencia</p></div>
+          <div><i class="fas fa-certificate text-red-600 text-3xl mb-2"></i><p>Certificación</p></div>
+          <div><i class="fas fa-users text-red-600 text-3xl mb-2"></i><p>Clientes</p></div>
+          <div><i class="fas fa-globe text-red-600 text-3xl mb-2"></i><p>Cobertura</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="nosotros" class="py-16 bg-red-950">
+      <div class="max-w-7xl mx-auto px-4">
+        <h2 class="text-2xl font-bold text-center mb-8">Nosotros</h2>
+        <p class="mb-4">DISIC es una empresa dedicada a la venta, renta y mantenimiento de extintores. Nuestro compromiso es ofrecer soluciones integrales de seguridad industrial y comercial.</p>
+        <div class="grid md:grid-cols-3 gap-6">
+          <div><h3 class="font-semibold mb-2">Misión</h3><p>Proteger la vida y el patrimonio de nuestros clientes.</p></div>
+          <div><h3 class="font-semibold mb-2">Visión</h3><p>Ser líderes en soluciones de seguridad contra incendios.</p></div>
+          <div><h3 class="font-semibold mb-2">Valores</h3><p>Compromiso, innovación y servicio.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="contacto" class="py-16">
+      <div class="max-w-7xl mx-auto px-4">
+        <h2 class="text-2xl font-bold text-center mb-8">Contacto</h2>
+        <form class="grid gap-4 md:grid-cols-2">
+          <input type="text" placeholder="Nombre" class="border p-2 rounded"/>
+          <input type="email" placeholder="Correo" class="border p-2 rounded"/>
+          <textarea placeholder="Mensaje" class="border p-2 rounded md:col-span-2" rows="4"></textarea>
+          <button class="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 md:col-span-2" type="submit">Enviar</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="bg-red-800 text-white py-6">
+    <div class="max-w-7xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center">
+      <p>&copy; 2025 DISIC</p>
+      <div class="space-x-4 text-xl">
+        <a href="#" class="hover:text-red-500"><i class="fab fa-facebook"></i></a>
+        <a href="#" class="hover:text-red-500"><i class="fab fa-instagram"></i></a>
+        <a href="#" class="hover:text-red-500"><i class="fab fa-linkedin"></i></a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    const menuToggle = document.getElementById('menu-toggle');
+    const mobileMenu = document.getElementById('mobile-menu');
+
+    menuToggle.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The page rendered black because it relied on a client-side React/Babel runtime that wasn't being compiled in this environment, so the intent is to ensure the site renders without client-side compilation.
- Replace the React-based app with plain static markup and a small vanilla JS menu toggle to make the page immediately usable in static hosting.

### Description
- Replaced the React/JSX and Babel runtime with a single static `static/index.html` that contains the full markup and removes `div#root` and the `text/babel` script.
- Kept Tailwind and FontAwesome assets while converting `className`/JSX into standard HTML `class` attributes and preserving layout and content.
- Added an accessible mobile menu button with `id="menu-toggle"` and a vanilla JS snippet that toggles the `#mobile-menu` visibility.
- Preserved the hero video (`fire.mp4`) and content sections so the visual design remains unchanged while removing the React dependency.

### Testing
- Served the `static` directory with `python -m http.server` and ran an automated Playwright script that opened `http://127.0.0.1:8000/index.html` and saved a screenshot, which completed successfully and produced an artifact.
- No automated unit or integration test suites were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec57a3c848324b38095c6628d9173)