### PR TITLE
Actualiza navegación y logo en la portada

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -41,15 +41,14 @@
       }
 
       .logo {
-        font-size: 1.25rem;
-        font-weight: 600;
-        letter-spacing: 0.08em;
-        color: var(--text);
-        text-transform: uppercase;
+        display: flex;
+        align-items: center;
       }
 
-      .logo span {
-        color: var(--accent);
+      .logo-image {
+        width: 148px;
+        height: auto;
+        display: block;
       }
 
       .nav-links {
@@ -156,12 +155,13 @@
   <body>
     <header>
       <nav>
-        <div class="logo">DISIC <span>WEB</span></div>
+        <div class="logo">
+          <img class="logo-image" src="images/disiclogo.png" alt="DISIC WEB" />
+        </div>
         <ul class="nav-links">
           <li><a href="#extintores">Extintores</a></li>
-          <li><a href="#sistemas">Sistemas contra incendios</a></li>
           <li><a href="#impresion">Impresión digital</a></li>
-          <li><a href="#inicio">Inicio</a></li>
+          <li><a href="#sistemas">Sistemas contra incendios</a></li>
           <li><a href="#clientes">Clientes</a></li>
           <li><a href="#contacto">Contacto</a></li>
         </ul>
@@ -187,16 +187,16 @@
             atención inmediata.
           </p>
         </article>
-        <article class="card" id="sistemas">
-          <h2>Sistemas contra incendios</h2>
-          <p>
-            Diseño, instalación y soporte técnico para infraestructuras críticas.
-          </p>
-        </article>
         <article class="card" id="impresion">
           <h2>Impresión digital</h2>
           <p>
             Soluciones de impresión de alta calidad para marcas exigentes.
+          </p>
+        </article>
+        <article class="card" id="sistemas">
+          <h2>Sistemas contra incendios</h2>
+          <p>
+            Diseño, instalación y soporte técnico para infraestructuras críticas.
           </p>
         </article>
         <article class="card" id="clientes">


### PR DESCRIPTION
### Motivation
- Ajustar la portada para usar el logo gráfico `disiclogo.png` en lugar del texto y simplificar la navegación. 
- Reorganizar las secciones para que las tarjetas de `Clientes` y `Contacto` aparezcan después de `Extintores`, `Impresión digital` y `Sistemas contra incendios` según la nueva estructura deseada.

### Description
- Reemplazado el logo textual por una etiqueta `<img>` que carga `images/disiclogo.png` y añadida la clase CSS `.logo-image` para controlar el tamaño.
- Actualizada la regla `.logo` en el CSS para usar `display: flex` y alineación, y añadida la clase `.logo-image` con `width: 148px`.
- Eliminado el enlace `Inicio` del menú de navegación y reordenados los enlaces para reflejar la nueva prioridad.
- Reordenadas las tarjetas HTML dentro de la sección `.sections` para que `Clientes` y `Contacto` queden al final después de `Extintores`, `Impresión digital` y `Sistemas contra incendios`.

### Testing
- Se inició un servidor estático con `python -m http.server 8000` en `/workspace/DISIC-WEB/static`, el servidor respondió correctamente.
- Se intentó una captura de rendering automática con Playwright para validar visualmente, pero la ejecución falló por un crash de Chromium (`SIGSEGV`) en este entorno, por lo que no se generó la captura.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697660fe64f88324ac401507e283dd05)