### PR TITLE
Add '¿Quiénes somos?' and Misión/Visión/Valores, reorder sections, darken red

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -9,7 +9,7 @@
         color-scheme: dark;
         --bg: #0b0b0b;
         --surface: #111111;
-        --accent: #e11d2e;
+        --accent: #b31324;
         --text: #f5f5f5;
         --muted: #b0b0b0;
       }
@@ -162,6 +162,7 @@
           <li><a href="#extintores">Extintores</a></li>
           <li><a href="#impresion">Impresión digital</a></li>
           <li><a href="#sistemas">Sistemas contra incendios</a></li>
+          <li><a href="#quienes-somos">¿Quiénes somos?</a></li>
           <li><a href="#clientes">Clientes</a></li>
           <li><a href="#contacto">Contacto</a></li>
         </ul>
@@ -177,6 +178,58 @@
           digital.
         </p>
         <a class="cta" href="#contacto">Habla con nosotros</a>
+      </section>
+
+      <section class="card" id="quienes-somos">
+        <h2>¿QUIÉNES SOMOS?</h2>
+        <p>
+          DISIC Despacho Integral de Seguridad Industrial y Comercial es una
+          empresa 100% mexicana, líder en la región de Baja California.
+          Conformada por divisiones representadas por expertos en la materia.
+        </p>
+        <p>
+          En DISIC puedes encontrar la venta y recarga de extinguidores, equipos
+          de seguridad industrial, equipos contra incendio, equipo de protección
+          personal, sistemas contra incendio, detección de incendio e
+          impartición de cursos, capacitaciones y entrenamiento de brigadas
+          solicitados por bomberos, Protección Civil y la STPS, programa interno
+          de Protección Civil (PIPC), plan de atención de emergencia, plan de
+          análisis de riesgo y más.
+        </p>
+        <p>
+          Contamos con más de 10 años de experiencia que respaldan la calidad de
+          nuestros servicios. Trabajamos en todas las áreas de seguridad al
+          facilitar la renta, compra, adquisición, mantenimiento o capacitación
+          que requiera.
+        </p>
+      </section>
+
+      <section class="sections">
+        <article class="card" id="mision">
+          <h2>Misión</h2>
+          <p>
+            Ofrecer la mejor solución a todos los problemas de seguridad
+            industrial que se pudieran presentar a nuestros clientes, todo
+            acompañado de un excelente servicio y precios altamente
+            competitivos.
+          </p>
+        </article>
+        <article class="card" id="vision">
+          <h2>Visión</h2>
+          <p>
+            Ser una compañía líder en la Región de Baja California, respondiendo
+            a las necesidades de nuestros clientes y nuestro entorno con los
+            estándares de calidad en el servicio más altos.
+          </p>
+        </article>
+        <article class="card" id="valores">
+          <h2>Valores</h2>
+          <p>
+            Los valores que nos rigen siempre estarán en función de brindar el
+            mejor servicio y ofrecerle la mejor atención a nuestros clientes.
+          </p>
+          <p>• Respeto • Apoyo • Empatía • Honestidad • Responsabilidad</p>
+        </article>
       </section>
 
       <section class="sections">
@@ -199,6 +252,9 @@
             Diseño, instalación y soporte técnico para infraestructuras críticas.
           </p>
         </article>
+      </section>
+
+      <section class="sections">
         <article class="card" id="clientes">
           <h2>Clientes</h2>
           <p>


### PR DESCRIPTION
### Motivation
- Implement requested homepage updates by adding a company overview and moving Clientes/Contacto below the service cards.
- Present the Misión, Visión and Valores as three separate cards for clearer structure.
- Make the accent red slightly darker to match the branding request.

### Description
- Updated `static/index.html` to change the CSS variable `--accent` from `#e11d2e` to `#b31324`.
- Added a navigation link to `#quienes-somos` and inserted a new `section` with the company overview content.
- Added three new card articles with ids `mision`, `vision`, and `valores`, and reorganized the markup so `clientes` and `contacto` appear after the service sections.
- Change is limited to static HTML/CSS with no JavaScript changes.

### Testing
- Launched a static server using `python -m http.server 8000`, which started successfully.
- Ran a Playwright script to load the homepage and capture a full-page screenshot, which completed and produced `artifacts/disic-home.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697663a832e4832489fe881b077f35dd)